### PR TITLE
Add symlink for spacepara115 and redactionpreviewexport icons

### DIFF
--- a/build/mate/png/links.txt
+++ b/build/mate/png/links.txt
@@ -488,6 +488,7 @@ cmd/32/recalcpivottable.png cmd/32/dataarearefresh.png
 cmd/32/recsave.png cmd/32/save.png
 cmd/32/rectangletoolbox.png cmd/32/rect.png
 cmd/32/recundo.png cmd/32/undo.png
+cmd/32/redactionpreviewexport.png cmd/32/exportdirecttopdf.png
 cmd/32/refresh.png cmd/32/reload.png
 cmd/32/refreshformcontrol.png cmd/32/reload.png
 cmd/32/rehearsetimings.png cmd/32/timefield.png
@@ -551,6 +552,7 @@ cmd/32/solverdialog.png cmd/32/helpindex.png
 cmd/32/sortdown.png cmd/32/sortdescending.png
 cmd/32/sortup.png cmd/32/sortascending.png
 cmd/32/sourceview.png cmd/32/symbolshapes.brace-pair.png
+cmd/32/spacepara115.png cmd/32/spacepara1.png
 cmd/32/spelldialog.png cmd/32/spelling.png
 cmd/32/spellingandgrammardialog.png cmd/32/spelling.png
 cmd/32/starchartdialog.png cmd/32/insertobjectdialog.png
@@ -1160,6 +1162,7 @@ cmd/lc_recalcpivottable.png cmd/lc_dataarearefresh.png
 cmd/lc_recsave.png cmd/lc_save.png
 cmd/lc_rectangletoolbox.png cmd/lc_rect.png
 cmd/lc_recundo.png cmd/lc_undo.png
+cmd/lc_redactionpreviewexport.png cmd/lc_exportdirecttopdf.png
 cmd/lc_refresh.png cmd/lc_reload.png
 cmd/lc_refreshformcontrol.png cmd/lc_reload.png
 cmd/lc_rehearsetimings.png cmd/lc_timefield.png
@@ -1218,6 +1221,7 @@ cmd/lc_sortdown.png cmd/lc_sortdescending.png
 cmd/lc_sortup.png cmd/lc_sortascending.png
 cmd/lc_sourcecharstyle.png cmd/lc_insertscript.png
 cmd/lc_sourceview.png cmd/lc_symbolshapes.brace-pair.png
+cmd/lc_spacepara115.png cmd/lc_spacepara1.png
 cmd/lc_spelldialog.png cmd/lc_spelling.png
 cmd/lc_spellingandgrammardialog.png cmd/lc_spelling.png
 cmd/lc_starchartdialog.png cmd/lc_insertobjectdialog.png
@@ -1710,6 +1714,7 @@ cmd/sc_recalcpivottable.png cmd/sc_dataarearefresh.png
 cmd/sc_recsave.png cmd/sc_save.png
 cmd/sc_rectangletoolbox.png cmd/sc_rect.png
 cmd/sc_recundo.png cmd/sc_undo.png
+cmd/sc_redactionpreviewexport.png cmd/sc_exportdirecttopdf.png
 cmd/sc_refresh.png cmd/sc_reload.png
 cmd/sc_refreshformcontrol.png cmd/sc_reload.png
 cmd/sc_rehearsetimings.png cmd/sc_timefield.png
@@ -1769,6 +1774,7 @@ cmd/sc_sortdown.png cmd/sc_sortdescending.png
 cmd/sc_sortup.png cmd/sc_sortascending.png
 cmd/sc_sourcecharstyle.png cmd/sc_insertscript.png
 cmd/sc_sourceview.png cmd/sc_symbolshapes.brace-pair.png
+cmd/sc_spacepara115.png cmd/sc_spacepara1.png
 cmd/sc_spelldialog.png cmd/sc_spelling.png
 cmd/sc_spellingandgrammardialog.png cmd/sc_spelling.png
 cmd/sc_starchartdialog.png cmd/sc_insertobjectdialog.png

--- a/build/mate/svg/links.txt
+++ b/build/mate/svg/links.txt
@@ -488,6 +488,7 @@ cmd/32/recalcpivottable.svg cmd/32/dataarearefresh.svg
 cmd/32/recsave.svg cmd/32/save.svg
 cmd/32/rectangletoolbox.svg cmd/32/rect.svg
 cmd/32/recundo.svg cmd/32/undo.svg
+cmd/32/redactionpreviewexport.svg cmd/32/exportdirecttopdf.svg
 cmd/32/refresh.svg cmd/32/reload.svg
 cmd/32/refreshformcontrol.svg cmd/32/reload.svg
 cmd/32/rehearsetimings.svg cmd/32/timefield.svg
@@ -551,6 +552,7 @@ cmd/32/solverdialog.svg cmd/32/helpindex.svg
 cmd/32/sortdown.svg cmd/32/sortdescending.svg
 cmd/32/sortup.svg cmd/32/sortascending.svg
 cmd/32/sourceview.svg cmd/32/symbolshapes.brace-pair.svg
+cmd/32/spacepara115.svg cmd/32/spacepara1.svg
 cmd/32/spelldialog.svg cmd/32/spelling.svg
 cmd/32/spellingandgrammardialog.svg cmd/32/spelling.svg
 cmd/32/starchartdialog.svg cmd/32/insertobjectdialog.svg
@@ -1160,6 +1162,7 @@ cmd/lc_recalcpivottable.svg cmd/lc_dataarearefresh.svg
 cmd/lc_recsave.svg cmd/lc_save.svg
 cmd/lc_rectangletoolbox.svg cmd/lc_rect.svg
 cmd/lc_recundo.svg cmd/lc_undo.svg
+cmd/lc_redactionpreviewexport.svg cmd/lc_exportdirecttopdf.svg
 cmd/lc_refresh.svg cmd/lc_reload.svg
 cmd/lc_refreshformcontrol.svg cmd/lc_reload.svg
 cmd/lc_rehearsetimings.svg cmd/lc_timefield.svg
@@ -1218,6 +1221,7 @@ cmd/lc_sortdown.svg cmd/lc_sortdescending.svg
 cmd/lc_sortup.svg cmd/lc_sortascending.svg
 cmd/lc_sourcecharstyle.svg cmd/lc_insertscript.svg
 cmd/lc_sourceview.svg cmd/lc_symbolshapes.brace-pair.svg
+cmd/lc_spacepara115.svg cmd/lc_spacepara1.svg
 cmd/lc_spelldialog.svg cmd/lc_spelling.svg
 cmd/lc_spellingandgrammardialog.svg cmd/lc_spelling.svg
 cmd/lc_starchartdialog.svg cmd/lc_insertobjectdialog.svg
@@ -1710,6 +1714,7 @@ cmd/sc_recalcpivottable.svg cmd/sc_dataarearefresh.svg
 cmd/sc_recsave.svg cmd/sc_save.svg
 cmd/sc_rectangletoolbox.svg cmd/sc_rect.svg
 cmd/sc_recundo.svg cmd/sc_undo.svg
+cmd/sc_redactionpreviewexport.svg cmd/sc_exportdirecttopdf.svg
 cmd/sc_refresh.svg cmd/sc_reload.svg
 cmd/sc_refreshformcontrol.svg cmd/sc_reload.svg
 cmd/sc_rehearsetimings.svg cmd/sc_timefield.svg
@@ -1769,6 +1774,7 @@ cmd/sc_sortdown.svg cmd/sc_sortdescending.svg
 cmd/sc_sortup.svg cmd/sc_sortascending.svg
 cmd/sc_sourcecharstyle.svg cmd/sc_insertscript.svg
 cmd/sc_sourceview.svg cmd/sc_symbolshapes.brace-pair.svg
+cmd/sc_spacepara115.svg cmd/sc_spacepara1.svg
 cmd/sc_spelldialog.svg cmd/sc_spelling.svg
 cmd/sc_spellingandgrammardialog.svg cmd/sc_spelling.svg
 cmd/sc_starchartdialog.svg cmd/sc_insertobjectdialog.svg

--- a/build/png/links.txt
+++ b/build/png/links.txt
@@ -488,6 +488,7 @@ cmd/32/recalcpivottable.png cmd/32/dataarearefresh.png
 cmd/32/recsave.png cmd/32/save.png
 cmd/32/rectangletoolbox.png cmd/32/rect.png
 cmd/32/recundo.png cmd/32/undo.png
+cmd/32/redactionpreviewexport.png cmd/32/exportdirecttopdf.png
 cmd/32/refresh.png cmd/32/reload.png
 cmd/32/refreshformcontrol.png cmd/32/reload.png
 cmd/32/rehearsetimings.png cmd/32/timefield.png
@@ -551,6 +552,7 @@ cmd/32/solverdialog.png cmd/32/helpindex.png
 cmd/32/sortdown.png cmd/32/sortdescending.png
 cmd/32/sortup.png cmd/32/sortascending.png
 cmd/32/sourceview.png cmd/32/symbolshapes.brace-pair.png
+cmd/32/spacepara115.png cmd/32/spacepara1.png
 cmd/32/spelldialog.png cmd/32/spelling.png
 cmd/32/spellingandgrammardialog.png cmd/32/spelling.png
 cmd/32/starchartdialog.png cmd/32/insertobjectdialog.png
@@ -1160,6 +1162,7 @@ cmd/lc_recalcpivottable.png cmd/lc_dataarearefresh.png
 cmd/lc_recsave.png cmd/lc_save.png
 cmd/lc_rectangletoolbox.png cmd/lc_rect.png
 cmd/lc_recundo.png cmd/lc_undo.png
+cmd/lc_redactionpreviewexport.png cmd/lc_exportdirecttopdf.png
 cmd/lc_refresh.png cmd/lc_reload.png
 cmd/lc_refreshformcontrol.png cmd/lc_reload.png
 cmd/lc_rehearsetimings.png cmd/lc_timefield.png
@@ -1218,6 +1221,7 @@ cmd/lc_sortdown.png cmd/lc_sortdescending.png
 cmd/lc_sortup.png cmd/lc_sortascending.png
 cmd/lc_sourcecharstyle.png cmd/lc_insertscript.png
 cmd/lc_sourceview.png cmd/lc_symbolshapes.brace-pair.png
+cmd/lc_spacepara115.png cmd/lc_spacepara1.png
 cmd/lc_spelldialog.png cmd/lc_spelling.png
 cmd/lc_spellingandgrammardialog.png cmd/lc_spelling.png
 cmd/lc_starchartdialog.png cmd/lc_insertobjectdialog.png
@@ -1710,6 +1714,7 @@ cmd/sc_recalcpivottable.png cmd/sc_dataarearefresh.png
 cmd/sc_recsave.png cmd/sc_save.png
 cmd/sc_rectangletoolbox.png cmd/sc_rect.png
 cmd/sc_recundo.png cmd/sc_undo.png
+cmd/sc_redactionpreviewexport.png cmd/sc_exportdirecttopdf.png
 cmd/sc_refresh.png cmd/sc_reload.png
 cmd/sc_refreshformcontrol.png cmd/sc_reload.png
 cmd/sc_rehearsetimings.png cmd/sc_timefield.png
@@ -1769,6 +1774,7 @@ cmd/sc_sortdown.png cmd/sc_sortdescending.png
 cmd/sc_sortup.png cmd/sc_sortascending.png
 cmd/sc_sourcecharstyle.png cmd/sc_insertscript.png
 cmd/sc_sourceview.png cmd/sc_symbolshapes.brace-pair.png
+cmd/sc_spacepara115.png cmd/sc_spacepara1.png
 cmd/sc_spelldialog.png cmd/sc_spelling.png
 cmd/sc_spellingandgrammardialog.png cmd/sc_spelling.png
 cmd/sc_starchartdialog.png cmd/sc_insertobjectdialog.png

--- a/build/svg/links.txt
+++ b/build/svg/links.txt
@@ -488,6 +488,7 @@ cmd/32/recalcpivottable.svg cmd/32/dataarearefresh.svg
 cmd/32/recsave.svg cmd/32/save.svg
 cmd/32/rectangletoolbox.svg cmd/32/rect.svg
 cmd/32/recundo.svg cmd/32/undo.svg
+cmd/32/redactionpreviewexport.svg cmd/32/exportdirecttopdf.svg
 cmd/32/refresh.svg cmd/32/reload.svg
 cmd/32/refreshformcontrol.svg cmd/32/reload.svg
 cmd/32/rehearsetimings.svg cmd/32/timefield.svg
@@ -551,6 +552,7 @@ cmd/32/solverdialog.svg cmd/32/helpindex.svg
 cmd/32/sortdown.svg cmd/32/sortdescending.svg
 cmd/32/sortup.svg cmd/32/sortascending.svg
 cmd/32/sourceview.svg cmd/32/symbolshapes.brace-pair.svg
+cmd/32/spacepara115.svg cmd/32/spacepara1.svg
 cmd/32/spelldialog.svg cmd/32/spelling.svg
 cmd/32/spellingandgrammardialog.svg cmd/32/spelling.svg
 cmd/32/starchartdialog.svg cmd/32/insertobjectdialog.svg
@@ -1160,6 +1162,7 @@ cmd/lc_recalcpivottable.svg cmd/lc_dataarearefresh.svg
 cmd/lc_recsave.svg cmd/lc_save.svg
 cmd/lc_rectangletoolbox.svg cmd/lc_rect.svg
 cmd/lc_recundo.svg cmd/lc_undo.svg
+cmd/lc_redactionpreviewexport.svg cmd/lc_exportdirecttopdf.svg
 cmd/lc_refresh.svg cmd/lc_reload.svg
 cmd/lc_refreshformcontrol.svg cmd/lc_reload.svg
 cmd/lc_rehearsetimings.svg cmd/lc_timefield.svg
@@ -1218,6 +1221,7 @@ cmd/lc_sortdown.svg cmd/lc_sortdescending.svg
 cmd/lc_sortup.svg cmd/lc_sortascending.svg
 cmd/lc_sourcecharstyle.svg cmd/lc_insertscript.svg
 cmd/lc_sourceview.svg cmd/lc_symbolshapes.brace-pair.svg
+cmd/lc_spacepara115.svg cmd/lc_spacepara1.svg
 cmd/lc_spelldialog.svg cmd/lc_spelling.svg
 cmd/lc_spellingandgrammardialog.svg cmd/lc_spelling.svg
 cmd/lc_starchartdialog.svg cmd/lc_insertobjectdialog.svg
@@ -1710,6 +1714,7 @@ cmd/sc_recalcpivottable.svg cmd/sc_dataarearefresh.svg
 cmd/sc_recsave.svg cmd/sc_save.svg
 cmd/sc_rectangletoolbox.svg cmd/sc_rect.svg
 cmd/sc_recundo.svg cmd/sc_undo.svg
+cmd/sc_redactionpreviewexport.svg cmd/sc_exportdirecttopdf.svg
 cmd/sc_refresh.svg cmd/sc_reload.svg
 cmd/sc_refreshformcontrol.svg cmd/sc_reload.svg
 cmd/sc_rehearsetimings.svg cmd/sc_timefield.svg
@@ -1769,6 +1774,7 @@ cmd/sc_sortdown.svg cmd/sc_sortdescending.svg
 cmd/sc_sortup.svg cmd/sc_sortascending.svg
 cmd/sc_sourcecharstyle.svg cmd/sc_insertscript.svg
 cmd/sc_sourceview.svg cmd/sc_symbolshapes.brace-pair.svg
+cmd/sc_spacepara115.svg cmd/sc_spacepara1.svg
 cmd/sc_spelldialog.svg cmd/sc_spelling.svg
 cmd/sc_spellingandgrammardialog.svg cmd/sc_spelling.svg
 cmd/sc_starchartdialog.svg cmd/sc_insertobjectdialog.svg

--- a/src/links.txt
+++ b/src/links.txt
@@ -488,6 +488,7 @@ cmd/32/recalcpivottable.xxx cmd/32/dataarearefresh.xxx
 cmd/32/recsave.xxx cmd/32/save.xxx
 cmd/32/rectangletoolbox.xxx cmd/32/rect.xxx
 cmd/32/recundo.xxx cmd/32/undo.xxx
+cmd/32/redactionpreviewexport.xxx cmd/32/exportdirecttopdf.xxx
 cmd/32/refresh.xxx cmd/32/reload.xxx
 cmd/32/refreshformcontrol.xxx cmd/32/reload.xxx
 cmd/32/rehearsetimings.xxx cmd/32/timefield.xxx
@@ -551,6 +552,7 @@ cmd/32/solverdialog.xxx cmd/32/helpindex.xxx
 cmd/32/sortdown.xxx cmd/32/sortdescending.xxx
 cmd/32/sortup.xxx cmd/32/sortascending.xxx
 cmd/32/sourceview.xxx cmd/32/symbolshapes.brace-pair.xxx
+cmd/32/spacepara115.xxx cmd/32/spacepara1.xxx
 cmd/32/spelldialog.xxx cmd/32/spelling.xxx
 cmd/32/spellingandgrammardialog.xxx cmd/32/spelling.xxx
 cmd/32/starchartdialog.xxx cmd/32/insertobjectdialog.xxx
@@ -1160,6 +1162,7 @@ cmd/lc_recalcpivottable.xxx cmd/lc_dataarearefresh.xxx
 cmd/lc_recsave.xxx cmd/lc_save.xxx
 cmd/lc_rectangletoolbox.xxx cmd/lc_rect.xxx
 cmd/lc_recundo.xxx cmd/lc_undo.xxx
+cmd/lc_redactionpreviewexport.xxx cmd/lc_exportdirecttopdf.xxx
 cmd/lc_refresh.xxx cmd/lc_reload.xxx
 cmd/lc_refreshformcontrol.xxx cmd/lc_reload.xxx
 cmd/lc_rehearsetimings.xxx cmd/lc_timefield.xxx
@@ -1218,6 +1221,7 @@ cmd/lc_sortdown.xxx cmd/lc_sortdescending.xxx
 cmd/lc_sortup.xxx cmd/lc_sortascending.xxx
 cmd/lc_sourcecharstyle.xxx cmd/lc_insertscript.xxx
 cmd/lc_sourceview.xxx cmd/lc_symbolshapes.brace-pair.xxx
+cmd/lc_spacepara115.xxx cmd/lc_spacepara1.xxx
 cmd/lc_spelldialog.xxx cmd/lc_spelling.xxx
 cmd/lc_spellingandgrammardialog.xxx cmd/lc_spelling.xxx
 cmd/lc_starchartdialog.xxx cmd/lc_insertobjectdialog.xxx
@@ -1710,6 +1714,7 @@ cmd/sc_recalcpivottable.xxx cmd/sc_dataarearefresh.xxx
 cmd/sc_recsave.xxx cmd/sc_save.xxx
 cmd/sc_rectangletoolbox.xxx cmd/sc_rect.xxx
 cmd/sc_recundo.xxx cmd/sc_undo.xxx
+cmd/sc_redactionpreviewexport.xxx cmd/sc_exportdirecttopdf.xxx
 cmd/sc_refresh.xxx cmd/sc_reload.xxx
 cmd/sc_refreshformcontrol.xxx cmd/sc_reload.xxx
 cmd/sc_rehearsetimings.xxx cmd/sc_timefield.xxx
@@ -1769,6 +1774,7 @@ cmd/sc_sortdown.xxx cmd/sc_sortdescending.xxx
 cmd/sc_sortup.xxx cmd/sc_sortascending.xxx
 cmd/sc_sourcecharstyle.xxx cmd/sc_insertscript.xxx
 cmd/sc_sourceview.xxx cmd/sc_symbolshapes.brace-pair.xxx
+cmd/sc_spacepara115.xxx cmd/sc_spacepara1.xxx
 cmd/sc_spelldialog.xxx cmd/sc_spelling.xxx
 cmd/sc_spellingandgrammardialog.xxx cmd/sc_spelling.xxx
 cmd/sc_starchartdialog.xxx cmd/sc_insertobjectdialog.xxx


### PR DESCRIPTION
Add symlink for `spacepara115` and `redactionpreviewexport` icons.

Related to https://github.com/rizmut/libreoffice-style-colibre/pull/10 and https://github.com/rizmut/libreoffice-style-colibre/pull/11