### PR TITLE
added build fail check to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,10 @@ then
 else
 	./build.sh --oxt
 
+	if [[ $? -ne 0 ]]; then
+	    exit 1
+	fi
+
 	echo -e "\n=> 🔥 Removing old install\n"
 
 	uninstall


### PR DESCRIPTION
It checks if the build exited with something other than zero and in case it did exits the install script with 1.
Fixes #283 